### PR TITLE
Add backend API setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.env
+venv/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY flashintel ./flashintel
+
+CMD ["uvicorn", "flashintel.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/flashintel/app.py
+++ b/backend/flashintel/app.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/health")
+async def health_check():
+    return {"status": "ok"}

--- a/backend/flashintel/celery_app.py
+++ b/backend/flashintel/celery_app.py
@@ -1,0 +1,11 @@
+from celery import Celery
+
+celery_app = Celery(
+    'flashintel',
+    broker='redis://redis:6379/0',
+    backend='redis://redis:6379/0'
+)
+
+@celery_app.task
+def ping():
+    return 'pong'

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn[standard]
+celery[redis]
+psycopg2-binary

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.9'
+services:
+  api:
+    build: ./backend
+    command: uvicorn flashintel.app:app --host 0.0.0.0 --port 8000
+    ports:
+      - "8000:8000"
+    depends_on:
+      - redis
+      - postgres
+  worker:
+    build: ./backend
+    command: celery -A flashintel.celery_app worker --loglevel=info
+    depends_on:
+      - redis
+      - postgres
+  redis:
+    image: redis:7-alpine
+  postgres:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: app_db
+    ports:
+      - "5432:5432"


### PR DESCRIPTION
## Summary
- set up FastAPI backend and Celery config
- add containerization for backend
- define services in docker-compose

## Testing
- `python -m pip install -r backend/requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684e86e6f32c832bbee67bb9d9916d2b