### PR TITLE
Add FastAPI skeleton with metrics and Celery

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,16 @@ Each coupon entitles the holder to request a single 3D printing project from Bea
 
 ## 6. Agreement
 By using the coupon, the holder agrees to these terms, ensuring a smooth process and allowing adequate time for project completion.
+
+## Monitoring
+
+The `flashintel` FastAPI application exposes Prometheus metrics on `/metrics` via
+`prometheus-fastapi-instrumentator`. Celery tasks can be monitored using Flower:
+
+```bash
+celery -A flashintel.celery_app flower
+```
+
+To visualize metrics with Grafana, add Prometheus as a data source in Grafana and
+import dashboards that target the application's metrics endpoint. Point the data
+source to the Prometheus server scraping the FastAPI application.

--- a/flashintel/app.py
+++ b/flashintel/app.py
@@ -1,0 +1,13 @@
+from fastapi import FastAPI
+from prometheus_fastapi_instrumentator import Instrumentator
+from .tasks import example_task
+
+app = FastAPI(title="Flashintel")
+
+# Initialize Prometheus metrics
+Instrumentator().instrument(app).expose(app)
+
+@app.get("/add")
+def add(x: int, y: int):
+    task = example_task.delay(x, y)
+    return {"task_id": task.id}

--- a/flashintel/celery_app.py
+++ b/flashintel/celery_app.py
@@ -1,0 +1,11 @@
+from celery import Celery
+import os
+
+BROKER_URL = os.getenv('CELERY_BROKER_URL', 'redis://localhost:6379/0')
+BACKEND_URL = os.getenv('CELERY_RESULT_BACKEND', 'redis://localhost:6379/1')
+
+celery_app = Celery('flashintel', broker=BROKER_URL, backend=BACKEND_URL)
+
+celery_app.conf.update(
+    task_track_started=True,
+)

--- a/flashintel/tasks.py
+++ b/flashintel/tasks.py
@@ -1,0 +1,5 @@
+from .celery_app import celery_app
+
+@celery_app.task
+def example_task(x, y):
+    return x + y

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+prometheus-fastapi-instrumentator
+celery
+redis


### PR DESCRIPTION
## Summary
- implement minimal FastAPI app in `flashintel` with Prometheus metrics exposure
- configure Celery and example task
- add dependencies list
- document metrics, Flower monitoring and Grafana dashboards

## Testing
- `python -m py_compile flashintel/app.py flashintel/celery_app.py flashintel/tasks.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684e86f36670832bba98699b2624c8ba